### PR TITLE
Included the gulpfile.js with the required operations

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,24 +1,24 @@
-const { watch, parallel } = require("gulp");
+const gulp = require('gulp');
+const { src, dest, watch, parallel, series } = require('gulp');
+const uglify = require('gulp-uglify');
+const imagemin = require('gulp-imagemin');
 
-function build(cb){
-    //scripts to build goes here
-
-
-
-
-    console.log("build completed");
-    cb();
-}
-function watching(cb){
-    watch("src/scripts/*.js",function(rb){
-        //The sccripts to go when watched
-
-
-
-        console.log("watched");
-        rb();
-    });
-    cb();
+async function minifyingjs(){
+    gulp.src('src/scripts/*.js')
+    .pipe(uglify())
+    .pipe(gulp.dest('dest/scripts'))
 }
 
-exports.default = parallel(build, watching);
+async function minifyingimg(){
+    gulp.src('src/icons/*')
+    .pipe(imagemin())
+    .pipe(gulp.dest('dest/icons'))
+}
+
+function watching(){
+    watch('src/scripts/*.js', series(minifyingjs));
+    watch('src/icons/*', series(minifyingimg));
+}
+
+
+exports.default = parallel(minifyingjs,minifyingimg, watching)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,24 @@
+const { watch, parallel } = require("gulp");
+
+function build(cb){
+    //scripts to build goes here
+
+
+
+
+    console.log("build completed");
+    cb();
+}
+function watching(cb){
+    watch("src/scripts/*.js",function(rb){
+        //The sccripts to go when watched
+
+
+
+        console.log("watched");
+        rb();
+    });
+    cb();
+}
+
+exports.default = parallel(build, watching);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-config-prettier": "^7.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.2.0",
+    "gulp": "^4.0.2",
     "husky": "^4.3.4",
     "lint-staged": "^10.5.3",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
     "src/**/*.js": [
       "eslint --fix"
     ]
+  },
+  "dependencies": {
+    "gulp-imagemin": "^7.1.0",
+    "gulp-uglify": "^3.0.2"
   }
 }


### PR DESCRIPTION
I have included the gulpfile for the required operations.

However it was not defined that what functions has to be executed under watch and build so i have kept the path to be watched at the js files in "src/scripts" for an example. It can be set easily and also i have written comments as to where the code of build and watch has to be added.